### PR TITLE
WP CLI requires `less`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN apt-get update \
       soap \
       xsl \
       sockets \
-      wddx
+      wddx \
+      less
 
 # install APCu from PECL
 RUN pecl -vvv install apcu && docker-php-ext-enable apcu


### PR DESCRIPTION
When launched without paremeters, WP CLI displays help via `less` pager